### PR TITLE
Feature/add paddle movement

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use ggez;
+use ggez::conf::WindowMode;
 use ggez::event;
 use ggez::{ContextBuilder, GameResult};
 
@@ -8,10 +9,11 @@ mod paddle;
 mod player;
 mod state;
 
-use state::MainState;
+use state::{MainState, WINDOW_HEIGHT, WINDOW_WIDTH};
 
 pub fn main() -> GameResult {
-    let cb = ContextBuilder::new("Pong", "Alibaba and the 50 Thieves");
+    let cb = ContextBuilder::new("Pong", "Alibaba and the 50 Thieves")
+        .window_mode(WindowMode::default().dimensions(WINDOW_WIDTH, WINDOW_HEIGHT));
     let (ctx, event_loop) = &mut cb.build()?;
     let state = &mut MainState::new()?;
     event::run(ctx, event_loop, state)

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use ggez::{ContextBuilder, GameResult};
 mod ball;
 mod draw;
 mod paddle;
+mod player;
 mod state;
 
 use state::MainState;

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -1,0 +1,41 @@
+#[cfg(test)]
+mod tests;
+
+pub const PLAYER_SPEED: f32 = 6.5;
+
+#[derive(Default)]
+pub struct Player {
+    pub position: (f32, f32),
+    is_moving: bool,
+    velocity: f32,
+}
+
+impl Player {
+    pub fn new(x: f32, y: f32) -> Self {
+        Self {
+            position: (x, y),
+            is_moving: false,
+            velocity: 0.0,
+        }
+    }
+
+    pub fn move_down(&mut self) {
+        self.is_moving = true;
+        self.velocity = PLAYER_SPEED;
+    }
+
+    pub fn move_up(&mut self) {
+        self.is_moving = true;
+        self.velocity = -PLAYER_SPEED;
+    }
+
+    pub fn stop_moving(&mut self) {
+        self.is_moving = false;
+    }
+
+    pub fn update(&mut self) {
+        if self.is_moving {
+            self.position.1 += self.velocity;
+        }
+    }
+}

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -1,7 +1,11 @@
 #[cfg(test)]
 mod tests;
 
+use crate::state::WINDOW_HEIGHT;
+
 pub const PLAYER_SPEED: f32 = 6.5;
+pub const PADDLE_WIDTH: f32 = 30.0;
+pub const PADDLE_HEIGHT: f32 = 150.0;
 
 #[derive(Default)]
 pub struct Player {
@@ -36,6 +40,22 @@ impl Player {
     pub fn update(&mut self) {
         if self.is_moving {
             self.position.1 += self.velocity;
+        }
+
+        self.handle_collisions();
+    }
+
+    fn handle_collisions(&mut self) {
+        self.window_collision();
+    }
+
+    fn window_collision(&mut self) {
+        if self.position.1 + PADDLE_HEIGHT > WINDOW_HEIGHT {
+            self.position.1 = WINDOW_HEIGHT - PADDLE_HEIGHT;
+        }
+
+        if self.position.1 < 0.0 {
+            self.position.1 = 0.0;
         }
     }
 }

--- a/src/player/tests.rs
+++ b/src/player/tests.rs
@@ -1,0 +1,52 @@
+use crate::player::{Player, PLAYER_SPEED};
+
+#[test]
+fn when_player_is_moving_stops_it() {
+    let mut player = Player::default();
+    player.is_moving = true;
+
+    player.stop_moving();
+
+    assert_eq!(player.is_moving, false);
+}
+
+#[test]
+fn move_down_makes_velocity_positive() {
+    let mut player = Player::default();
+    player.move_down();
+
+    assert_eq!(player.is_moving, true);
+    assert_eq!(player.velocity, PLAYER_SPEED);
+}
+
+#[test]
+fn move_up_makes_velocity_negative() {
+    let mut player = Player::default();
+    player.move_up();
+
+    assert_eq!(player.is_moving, true);
+    assert_eq!(player.velocity, -PLAYER_SPEED);
+}
+
+#[test]
+fn update_when_player_is_moving() {
+    let mut player = Player::default();
+    player.move_down();
+
+    let old_y_position = player.position.1;
+
+    player.update();
+
+    assert!(player.position.1 > old_y_position);
+}
+
+#[test]
+fn update_when_player_is_not_moving() {
+    let mut player = Player::default();
+
+    let old_y_position = player.position.1;
+
+    player.update();
+
+    assert_eq!(player.position.1, old_y_position);
+}

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,4 +1,4 @@
-use ggez::event;
+use ggez::event::{EventHandler, KeyCode, KeyMods};
 use ggez::graphics;
 use ggez::nalgebra as na;
 use ggez::{Context, GameResult};
@@ -6,13 +6,14 @@ use ggez::{Context, GameResult};
 use crate::ball::get_ball_graphics;
 use crate::draw::clear_background;
 use crate::paddle::get_paddle_graphics;
+use crate::player::Player;
 
 const PADDLE_WIDTH: f32 = 30.0;
 const PADDLE_HEIGHT: f32 = 150.0;
 
 pub struct MainState {
     pub ball_position: (f32, f32),
-    player_position: (f32, f32),
+    player: Player,
     enemy_position: (f32, f32),
 }
 
@@ -20,7 +21,7 @@ impl MainState {
     pub fn new() -> GameResult<MainState> {
         let s = MainState {
             ball_position: (400.0, 300.0),
-            player_position: (40.0, 225.0),
+            player: Player::new(40.0, 225.0),
             enemy_position: (800.0 - 70.0, 225.0),
         };
         Ok(s)
@@ -29,6 +30,8 @@ impl MainState {
     pub fn update(&mut self) {
         self.ball_position.0 += 3.0;
         self.ball_position.0 = self.ball_position.0 % 800.0;
+
+        self.player.update();
     }
 
     fn draw_ball(&mut self, ctx: &mut Context) -> GameResult {
@@ -40,8 +43,8 @@ impl MainState {
     fn draw_player(&mut self, ctx: &mut Context) -> GameResult {
         let player_paddle = get_paddle_graphics(
             ctx,
-            self.player_position.0,
-            self.player_position.1,
+            self.player.position.0,
+            self.player.position.1,
             PADDLE_WIDTH,
             PADDLE_HEIGHT,
         )?;
@@ -62,7 +65,7 @@ impl MainState {
     }
 }
 
-impl event::EventHandler for MainState {
+impl EventHandler for MainState {
     fn update(&mut self, _ctx: &mut Context) -> GameResult {
         self.update();
         Ok(())
@@ -77,6 +80,33 @@ impl event::EventHandler for MainState {
 
         graphics::present(ctx)?;
         Ok(())
+    }
+
+    fn key_down_event(
+        &mut self,
+        _ctx: &mut Context,
+        keycode: KeyCode,
+        _keymods: KeyMods,
+        _repeat: bool,
+    ) {
+        match keycode {
+            KeyCode::W => {
+                self.player.move_up();
+            }
+            KeyCode::S => {
+                self.player.move_down();
+            }
+            _ => (),
+        };
+    }
+
+    fn key_up_event(&mut self, _ctx: &mut Context, keycode: KeyCode, _keymods: KeyMods) {
+        match keycode {
+            KeyCode::W | KeyCode::S => {
+                self.player.stop_moving();
+            }
+            _ => (),
+        };
     }
 }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -6,13 +6,10 @@ use ggez::{Context, GameResult};
 use crate::ball::get_ball_graphics;
 use crate::draw::clear_background;
 use crate::paddle::get_paddle_graphics;
-use crate::player::Player;
+use crate::player::{Player, PADDLE_HEIGHT, PADDLE_WIDTH};
 
 pub const WINDOW_WIDTH: f32 = 800.0;
 pub const WINDOW_HEIGHT: f32 = 600.0;
-
-const PADDLE_WIDTH: f32 = 30.0;
-const PADDLE_HEIGHT: f32 = 150.0;
 
 pub struct MainState {
     pub ball_position: (f32, f32),

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -11,18 +11,20 @@ use crate::player::{Player, PADDLE_HEIGHT, PADDLE_WIDTH};
 pub const WINDOW_WIDTH: f32 = 800.0;
 pub const WINDOW_HEIGHT: f32 = 600.0;
 
+pub const GOAL_DISTANCE: f32 = 40.0;
+
 pub struct MainState {
     pub ball_position: (f32, f32),
-    player: Player,
-    enemy_position: (f32, f32),
+    player1: Player,
+    player2: Player,
 }
 
 impl MainState {
     pub fn new() -> GameResult<MainState> {
         let s = MainState {
             ball_position: (400.0, 300.0),
-            player: Player::new(40.0, 225.0),
-            enemy_position: (800.0 - 70.0, 225.0),
+            player1: Player::new(40.0, 225.0),
+            player2: Player::new(WINDOW_WIDTH - (PADDLE_WIDTH + GOAL_DISTANCE), 225.0),
         };
         Ok(s)
     }
@@ -31,7 +33,8 @@ impl MainState {
         self.ball_position.0 += 3.0;
         self.ball_position.0 = self.ball_position.0 % 800.0;
 
-        self.player.update();
+        self.player1.update();
+        self.player2.update();
     }
 
     fn draw_ball(&mut self, ctx: &mut Context) -> GameResult {
@@ -43,8 +46,8 @@ impl MainState {
     fn draw_player(&mut self, ctx: &mut Context) -> GameResult {
         let player_paddle = get_paddle_graphics(
             ctx,
-            self.player.position.0,
-            self.player.position.1,
+            self.player1.position.0,
+            self.player1.position.1,
             PADDLE_WIDTH,
             PADDLE_HEIGHT,
         )?;
@@ -55,8 +58,8 @@ impl MainState {
     fn draw_enemy(&mut self, ctx: &mut Context) -> GameResult {
         let enemy_paddle = get_paddle_graphics(
             ctx,
-            self.enemy_position.0,
-            self.enemy_position.1,
+            self.player2.position.0,
+            self.player2.position.1,
             PADDLE_WIDTH,
             PADDLE_HEIGHT,
         )?;
@@ -91,10 +94,16 @@ impl EventHandler for MainState {
     ) {
         match keycode {
             KeyCode::W => {
-                self.player.move_up();
+                self.player1.move_up();
             }
             KeyCode::S => {
-                self.player.move_down();
+                self.player1.move_down();
+            }
+            KeyCode::Up => {
+                self.player2.move_up();
+            }
+            KeyCode::Down => {
+                self.player2.move_down();
             }
             _ => (),
         };
@@ -103,7 +112,10 @@ impl EventHandler for MainState {
     fn key_up_event(&mut self, _ctx: &mut Context, keycode: KeyCode, _keymods: KeyMods) {
         match keycode {
             KeyCode::W | KeyCode::S => {
-                self.player.stop_moving();
+                self.player1.stop_moving();
+            }
+            KeyCode::Up | KeyCode::Down => {
+                self.player2.stop_moving();
             }
             _ => (),
         };

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -8,6 +8,9 @@ use crate::draw::clear_background;
 use crate::paddle::get_paddle_graphics;
 use crate::player::Player;
 
+pub const WINDOW_WIDTH: f32 = 800.0;
+pub const WINDOW_HEIGHT: f32 = 600.0;
+
 const PADDLE_WIDTH: f32 = 30.0;
 const PADDLE_HEIGHT: f32 = 150.0;
 


### PR DESCRIPTION
Esse PR:

- Cria uma `struct` chamada `Player` para guardar estado e funções relacionadas ao jogador;
- Utiliza uma instância dela dentro do `MainState` ao invés de somente a tupla com as posições de `x` e `y`;
- Na nova `struct` de `Player` existem métodos que ajudam para movimentação;
- Algumas constantes são movidas de lugar, e agora o tamanho da janela está no módulo `state`;
- O inimigo também virou um jogador.

No caso a ideia é que o `player1` seja o da esquerda, que controla com `W` e `S` seu movimento. E o `player2` é o da direita, controlando com as setas `Up` e `Down`.